### PR TITLE
Update maven repo URL to use HTTPS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ repositories {
     }
 
     maven {
-        url = 'http://repo.maven.apache.org/maven2'
+        url = 'https://repo.maven.apache.org/maven2'
     }
     mavenCentral()
 }


### PR DESCRIPTION
HTTP access is no longer supported.

https://support.sonatype.com/hc/en-us/articles/360041287334